### PR TITLE
Update graphs to support asyncio coroutines

### DIFF
--- a/examples/example0.py
+++ b/examples/example0.py
@@ -1,15 +1,15 @@
 import asyncio
 from time import time
 
-from magda.pipeline import SequentialPipeline
+from magda.pipeline.sequential import SequentialPipeline
 
-from examples.interfaces.common import Context, Request
+from examples.interfaces.common import Request, Context
 from examples.modules.a import ModuleA
 from examples.modules.b import ModuleB
 from examples.modules.c import ModuleC
 
 
-class ExampleSequential:
+class ExampleSimpleSequential:
     @classmethod
     async def demo(cls):
         example = cls()
@@ -33,28 +33,21 @@ class ExampleSequential:
 
         self.pipeline = await builder.build(lambda: Context(prefix))
 
-    async def run(self, value: str = 'R', n_jobs: int = 3):
-        # Run jobs and measure duration
+    async def run(self):
+        # Run one job and measure duration
         start = time()
-        results = await asyncio.gather(*[
-            asyncio.create_task(
-                self.pipeline.run(Request(value=f'{value}{i}'))
-            )
-            for i in range(n_jobs)
-        ])
+        result = await self.pipeline.run(Request('R'))
         end = time()
 
-        # Close pipeline and teardown modules
+        # Close pipeline (and teardown modules)
         await self.pipeline.close()
 
         # Print results
         print(f'Duration = {end - start:.2f} s')
         print('Results:')
-        for index, result in enumerate(results):
-            print(f' {index}:')
-            for key, value in result.items():
-                print(f'  {key}\t → {value}')
+        for key, value in result.items():
+            print(f'  {key}\t → {value}')
 
 
 if __name__ == "__main__":
-    asyncio.run(ExampleSequential.demo())
+    asyncio.run(ExampleSimpleSequential.demo())

--- a/examples/example2.py
+++ b/examples/example2.py
@@ -38,7 +38,7 @@ class ExampleParallel:
             .expose_result('final')
         )
 
-        self.pipeline = builder.build(lambda: Context(prefix))
+        self.pipeline = await builder.build(lambda: Context(prefix))
 
     async def run(self, value: str = 'R', n_jobs: int = 3):
         # Run jobs and measure duration

--- a/examples/example3.py
+++ b/examples/example3.py
@@ -38,7 +38,7 @@ class ExampleParallelActorPool:
             .expose_result('final')
         )
 
-        self.pipeline = builder.build(lambda: Context(prefix))
+        self.pipeline = await builder.build(lambda: Context(prefix))
 
     async def run(self, value: str = 'R', n_jobs: int = 3):
         # Execute jobs and measure duration

--- a/examples/modules/a.py
+++ b/examples/modules/a.py
@@ -1,9 +1,10 @@
+import asyncio
 from time import sleep
 
 from magda.module import Module
 from magda.decorators import register, accept, finalize, produce
 
-from examples.modules.common import logger, log
+from examples.modules.common import log
 from examples.interfaces.common import Request, Context
 from examples.interfaces.string import StringInterface
 from examples.interfaces.fn import LambdaInterface
@@ -20,14 +21,18 @@ class ModuleA(Module.Runtime):
         ctx: Context = self.context
         log(self, ctx.timer, '--- Created!')
 
-    def teardown(self):
+    async def teardown(self):
         ctx: Context = self.context
-        log(self, ctx.timer, '--- Teardown!')
+        log(self, ctx.timer, '--- Long...!')
+        await asyncio.sleep(1)
+        log(self, ctx.timer, '--- ...Teardown!')
 
-    @logger
     def run(self, data: Module.ResultSet, request: Request):
         # Access context
         ctx: Context = self.context
+
+        # Mark module's start
+        log(self, ctx.timer, '- Start')
 
         # Access results from the previous modules
         #   `src` is a list of strings
@@ -36,6 +41,9 @@ class ModuleA(Module.Runtime):
 
         # Some heavy computational operations for example
         sleep(self.SLEEP_TIME)
+
+        # Mark module's end
+        log(self, ctx.timer, '- End')
 
         # Produce declared interface
         return StringInterface(

--- a/examples/modules/b.py
+++ b/examples/modules/b.py
@@ -1,9 +1,9 @@
-from time import sleep
+import asyncio
 
 from magda.module import Module
 from magda.decorators import register, accept, finalize, produce
 
-from examples.modules.common import logger, log
+from examples.modules.common import log
 from examples.interfaces.common import Context
 from examples.interfaces.fn import LambdaInterface
 
@@ -23,13 +23,19 @@ class ModuleB(Module.Runtime):
         ctx: Context = self.context
         log(self, ctx.timer, '--- Teardown!')
 
-    @logger
-    def run(self, data: Module.ResultSet, *args, **kwargs):
+    async def run(self, data: Module.ResultSet, *args, **kwargs):
+        # Mark module's start
+        ctx: Context = self.context
+        log(self, ctx.timer, '- Start')
+
         # Access strings (results) from the previous modules
         src = [text.fn() for text in data.of(LambdaInterface)]
 
-        # Add delay for example purposes
-        sleep(self.SLEEP_TIME)
+        # E.g. some IO operation (delay for example purposes)
+        await asyncio.sleep(self.SLEEP_TIME)
+
+        # Mark module's end
+        log(self, ctx.timer, '- End')
 
         # Build output string and produce declared interface
         msg = '(' + ' + '.join(src) + (' = ' if len(src) else '') + f'{self.name})'

--- a/examples/modules/c.py
+++ b/examples/modules/c.py
@@ -3,7 +3,8 @@ from time import sleep
 from magda.module import Module
 from magda.decorators import register, accept, expose, finalize, produce
 
-from examples.modules.common import logger
+from examples.modules.common import log
+from examples.interfaces.common import Context
 from examples.interfaces.string import StringInterface
 
 
@@ -13,8 +14,11 @@ from examples.interfaces.string import StringInterface
 @register('C')
 @finalize
 class ModuleC(Module.Runtime):
-    @logger
-    def run(self, data: Module.ResultSet, *args, **kwargs):
+    async def run(self, data: Module.ResultSet, *args, **kwargs):
+        # Mark module's start
+        ctx: Context = self.context
+        log(self, ctx.timer, '- Start')
+
         # Access strings (results) from the previous modules
         src = [t.data for t in data.of(StringInterface)]
 
@@ -22,6 +26,9 @@ class ModuleC(Module.Runtime):
         #   delay duration is taken from optional parameter `sleep`
         #   and is 2 seconds by default (if the parameter is not provided)
         sleep(self.parameters.get('sleep', 2))
+
+        # Mark module's end
+        log(self, ctx.timer, '- End')
 
         # Build output string and produce declared interface
         return StringInterface(

--- a/examples/modules/common.py
+++ b/examples/modules/common.py
@@ -1,21 +1,6 @@
 from time import time
-from functools import wraps
-
 from magda.module import Module
-
-from examples.interfaces.common import Context
 
 
 def log(ref: Module.Runtime, t0: float, msg: str):
     print(f'{ref.__class__.__name__}::{ref.name} [{time() - t0:8.3f}] {msg}')
-
-
-def logger(fn):
-    @wraps(fn)
-    def wrapper(ref: Module.Runtime, *args, **kwargs):
-        ctx: Context = ref.context
-        log(ref, ctx.timer, '- Start')
-        output = fn(ref, *args, **kwargs)
-        log(ref, ctx.timer, '- End')
-        return output
-    return wrapper

--- a/magda/config_reader.py
+++ b/magda/config_reader.py
@@ -17,7 +17,7 @@ class ConfigReader:
         parameters: Dict[str, Any] = field(default=None)
 
     @classmethod
-    def read(
+    async def read(
         cls,
         config: str,
         module_factory: ModuleFactory,
@@ -49,7 +49,9 @@ class ConfigReader:
                         f"Module '{dependent_mod_name}' hasn't been defined in the config file, "
                         "whereas it's used as a dependency."
                     )
-        return pipeline.build(context, shared_parameters)
+
+        runtime = await pipeline.build(context, shared_parameters)
+        return runtime
 
     @staticmethod
     def _extract_information_from_yaml(parsed_yaml, shared_parameters):

--- a/magda/module/runtime.py
+++ b/magda/module/runtime.py
@@ -34,10 +34,6 @@ class ModuleRuntime(BaseModuleRuntime):
         self._parameters = parameters
 
     async def _on_bootstrap(self):
-        if isinstance(self._context, ray.ObjectRef):
-            self._context = await self._context
-        if isinstance(self._shared_parameters, ray.ObjectRef):
-            self._shared_parameters = await self._shared_parameters
         if callable(self._context):
             self._context = self._context()
 

--- a/magda/module/runtime.py
+++ b/magda/module/runtime.py
@@ -1,5 +1,5 @@
 from __future__ import annotations
-
+import asyncio
 from typing import Optional
 
 import ray
@@ -33,14 +33,18 @@ class ModuleRuntime(BaseModuleRuntime):
         self._is_regular_module = is_regular_module
         self._parameters = parameters
 
-    def _on_bootstrap(self):
+    async def _on_bootstrap(self):
         if isinstance(self._context, ray.ObjectRef):
             self._context = ray.get(self._context)
         if isinstance(self._shared_parameters, ray.ObjectRef):
             self._shared_parameters = ray.get(self._shared_parameters)
         if callable(self._context):
             self._context = self._context()
-        self.bootstrap()
+
+        if asyncio.iscoroutinefunction(self.bootstrap):
+            await self.bootstrap()
+        else:
+            self.bootstrap()
 
     def bootstrap(self):
         """ Bootstrap module on target device """

--- a/magda/module/runtime.py
+++ b/magda/module/runtime.py
@@ -35,9 +35,9 @@ class ModuleRuntime(BaseModuleRuntime):
 
     async def _on_bootstrap(self):
         if isinstance(self._context, ray.ObjectRef):
-            self._context = ray.get(self._context)
+            self._context = await self._context
         if isinstance(self._shared_parameters, ray.ObjectRef):
-            self._shared_parameters = ray.get(self._shared_parameters)
+            self._shared_parameters = await self._shared_parameters
         if callable(self._context):
             self._context = self._context()
 

--- a/magda/pipeline/base.py
+++ b/magda/pipeline/base.py
@@ -30,11 +30,11 @@ class BasePipeline(ABC):
             return self._shared_parameters
 
         @abstractmethod
-        def run(self, request):
+        async def run(self, request):
             raise NotImplementedError()
 
         @abstractmethod
-        def close(self):
+        async def close(self):
             raise NotImplementedError()
 
         @property

--- a/magda/pipeline/graph.py
+++ b/magda/pipeline/graph.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import asyncio
 from collections import defaultdict
-from typing import Any, List, Optional, Type
+from typing import Any, List, Optional
 
 from magda.module.module import Module
 
@@ -111,7 +111,7 @@ class Graph:
 
     def _should_be_run(
         self,
-        module: Type[Module.Runtime],
+        module: Module.Runtime,
         is_regular_runtime: bool,
     ) -> bool:
         if is_regular_runtime:
@@ -121,7 +121,7 @@ class Graph:
 
     def _exposed_result(
         self,
-        module: Type[Module.Runtime],
+        module: Module.Runtime,
         is_regular_runtime: bool,
     ) -> Optional[str]:
         if is_regular_runtime and issubclass(type(module), Module.Aggregate):
@@ -131,7 +131,7 @@ class Graph:
 
     async def _run_method_helper(
         self,
-        module: Type[Module.Runtime],
+        module: Module.Runtime,
         data: Module.ResultSet,
         request: Any,
         is_regular_runtime: bool,

--- a/magda/pipeline/parallel/group/actor.py
+++ b/magda/pipeline/parallel/group/actor.py
@@ -21,14 +21,11 @@ class Actor:
         await self.graph.bootstrap()
 
     async def run(self, job_id: UUID, request, results=[], is_regular_runtime=True):
+        result = await self.graph.run(request, results, is_regular_runtime)
         return FutureResult(
             job=job_id,
             group=self.name,
-            result=await self.graph.run(
-                request,
-                results,
-                is_regular_runtime=is_regular_runtime,
-            ),
+            result=result,
         )
 
     async def teardown(self):

--- a/magda/pipeline/parallel/group/actor.py
+++ b/magda/pipeline/parallel/group/actor.py
@@ -17,14 +17,19 @@ class Actor:
         self.state_type = state_type
         self.graph = Graph(modules)
 
-    def run(self, job_id: UUID, request, results=[], is_regular_runtime=True):
+    async def bootstrap(self):
+        await self.graph.bootstrap()
+
+    async def run(self, job_id: UUID, request, results=[], is_regular_runtime=True):
         return FutureResult(
             job=job_id,
             group=self.name,
-            result=self.graph.run(request, results,
-                                  is_regular_runtime=is_regular_runtime,
-                                  state_type=self.state_type),
+            result=await self.graph.run(
+                request,
+                results,
+                is_regular_runtime=is_regular_runtime,
+            ),
         )
 
-    def teardown(self):
-        self.graph.teardown()
+    async def teardown(self):
+        await self.graph.teardown()

--- a/magda/pipeline/parallel/group/actor_pool.py
+++ b/magda/pipeline/parallel/group/actor_pool.py
@@ -9,7 +9,8 @@ from magda.pipeline.parallel.group.actor import Actor
 class ParallelActorPool:
     def __init__(self, actors: List[Actor]):
         self._replicas = len(actors)
-        self._idle_actors = asyncio.Queue()
+        self._actors = actors
+        self._idle_actors: asyncio.Queue[Actor] = asyncio.Queue()
         for actor in actors:
             self._idle_actors.put_nowait(actor)
 
@@ -17,13 +18,19 @@ class ParallelActorPool:
     def replicas(self) -> int:
         return self._replicas
 
+    async def bootstrap(self):
+        await asyncio.gather(*[
+            actor.bootstrap.remote()
+            for actor in self._actors
+        ])
+
     async def run(self, **job):
         actor = await self._idle_actors.get()
         result = await actor.run.remote(**job)
         await self._idle_actors.put(actor)
         return result
 
-    async def teardown(self, **job):
+    async def teardown(self):
         for _ in range(self._replicas):
             actor = await self._idle_actors.get()
             await actor.teardown.remote()

--- a/magda/pipeline/parallel/group/runtime.py
+++ b/magda/pipeline/parallel/group/runtime.py
@@ -49,6 +49,9 @@ class GroupRuntime:
     def fulfills(self, names: Iterable[str]) -> bool:
         return set(names).issuperset(self.module_dependencies)
 
+    async def bootstrap(self):
+        await self.pool.bootstrap()
+
     async def run(self, job_id: UUID, request, results, is_regular_runtime):
         return asyncio.ensure_future(
             self.pool.run(

--- a/magda/pipeline/parallel/parallel_pipeline.py
+++ b/magda/pipeline/parallel/parallel_pipeline.py
@@ -1,8 +1,5 @@
 from __future__ import annotations
-
 from typing import List, Set
-
-import ray
 
 from magda.module.module import Module
 from magda.pipeline.base import BasePipeline
@@ -39,12 +36,9 @@ class ParallelPipeline(BasePipeline):
         if any([m.group is None for m in self.modules]):
             raise Exception('At least one module does not have a group property')
 
-        context_ref = ray.put(context)
-        shared_parameters_ref = ray.put(shared_parameters)
-
         self._mark_and_validate_modules(modules=self.modules)
         runtime_modules = [
-            module.build(context_ref, shared_parameters_ref)
+            module.build(context, shared_parameters)
             for module in self.modules
         ]
 
@@ -85,7 +79,7 @@ class ParallelPipeline(BasePipeline):
             await runtime_group.bootstrap()
             runtime_groups.append(runtime_group)
 
-        return Runtime(runtime_groups, context_ref, shared_parameters_ref)
+        return Runtime(runtime_groups, context, shared_parameters)
 
     @staticmethod
     def _exclude_own_modules(module_dependencies, modules):

--- a/magda/pipeline/parallel/runtime.py
+++ b/magda/pipeline/parallel/runtime.py
@@ -24,11 +24,11 @@ class Runtime(BasePipeline.Runtime):
 
     @property
     def context(self):
-        return ray.get(super().context)
+        return super().context
 
     @property
     def shared_parameters(self):
-        return ray.get(super().shared_parameters)
+        return super().shared_parameters
 
     @property
     def modules(self) -> List[Module.Runtime]:

--- a/magda/pipeline/sequential.py
+++ b/magda/pipeline/sequential.py
@@ -27,20 +27,20 @@ class SequentialPipeline(BasePipeline):
         def closed(self) -> bool:
             return self._is_closed
 
-        def close(self):
+        async def close(self):
             self._is_closed = True
-            self.graph.teardown()
+            await self.graph.teardown()
 
-        def run(self, request=None, is_regular_runtime=True) -> Dict[str, Module.Result]:
+        async def run(self, request=None, is_regular_runtime=True) -> Dict[str, Module.Result]:
             if self._is_closed:
                 raise ClosedPipelineException()
-            results = self.graph.run(request=request, is_regular_runtime=is_regular_runtime)
+            results = await self.graph.run(request=request, is_regular_runtime=is_regular_runtime)
             return self.parse_results(results)
 
-        def process(self, request=None) -> Dict[str, Module.Result]:
-            return self.run(request=request, is_regular_runtime=False)
+        async def process(self, request=None) -> Dict[str, Module.Result]:
+            return await self.run(request=request, is_regular_runtime=False)
 
-    def build(self, context=None, shared_parameters=None) -> SequentialPipeline.Runtime:
+    async def build(self, context=None, shared_parameters=None) -> SequentialPipeline.Runtime:
         self.validate()
         if any([m.group is not None for m in self.modules]):
             msg = ', '.join([
@@ -55,6 +55,7 @@ class SequentialPipeline(BasePipeline):
         modules = [module.build(context, shared_parameters) for module in self.modules]
 
         graph = Graph(modules)
+        await graph.bootstrap()
         return self.Runtime(graph, context, shared_parameters)
 
     def _mark_and_validate_modules(self, modules):

--- a/magda/pipeline/sequential.py
+++ b/magda/pipeline/sequential.py
@@ -10,10 +10,10 @@ from magda.exceptions import ClosedPipelineException
 
 
 class SequentialPipeline(BasePipeline):
-    """ Synchronous processing pipeline """
+    """ Sequential processing pipeline """
 
     class Runtime(BasePipeline.Runtime):
-        """ Synchronous pipeline runner """
+        """ Sequential pipeline runner """
         def __init__(self, graph: Graph, context=None, shared_parameters=None):
             super().__init__(context, shared_parameters)
             self.graph = graph

--- a/test/test_actor_pool.py
+++ b/test/test_actor_pool.py
@@ -17,9 +17,9 @@ class MultiplyActor:
         return self.factor * data
 
 
-@pytest.fixture(scope='module')
+@pytest.fixture(scope='class')
 def ray_context():
-    ray.init(local_mode=True)
+    ray.init(num_cpus=1)
     yield None
     ray.shutdown()
 

--- a/test/test_decorator.py
+++ b/test/test_decorator.py
@@ -72,7 +72,8 @@ class TestDecorator:
             class NonModuleClass():
                 pass
 
-    def test_exposing_under_the_same_name(self):
+    @pytest.mark.asyncio
+    async def test_exposing_under_the_same_name(self):
 
         @expose('a')
         @accept(MockModuleA)
@@ -87,4 +88,4 @@ class TestDecorator:
         builder.add_module(MockModuleC('m2'))
 
         with pytest.raises(Exception):
-            pipeline = builder.build()
+            pipeline = await builder.build()

--- a/test/test_graph.py
+++ b/test/test_graph.py
@@ -15,7 +15,8 @@ class SkipModule(Module.Runtime):
 
 
 class TestGraph:
-    def test_should_fail_on_not_connected_graph(self):
+    @pytest.mark.asyncio
+    async def test_should_fail_on_not_connected_graph(self):
         builder = SequentialPipeline()
         builder.add_module(SkipModule('A'))
         builder.add_module(
@@ -31,9 +32,10 @@ class TestGraph:
             SkipModule('D')
         )
         with pytest.raises(DisjointGraphException):
-            results = builder.build().run()
+            results = await builder.build()
 
-    def test_should_not_fail_on_graph_without_cycle(self):
+    @pytest.mark.asyncio
+    async def test_should_not_fail_on_graph_without_cycle(self):
         builder = SequentialPipeline()
         builder.add_module(SkipModule('A'))
         builder.add_module(
@@ -48,10 +50,12 @@ class TestGraph:
             SkipModule('D')
             .depends_on(builder.get_module('C'))
         )
-        results = builder.build().run()
-        assert 4 == len(builder.modules)
 
-    def test_should_not_fail_on_branched_graph_without_cycle(self):
+        pipeline = await builder.build()
+        assert 4 == len(pipeline.modules)
+
+    @pytest.mark.asyncio
+    async def test_should_not_fail_on_branched_graph_without_cycle(self):
         builder = SequentialPipeline()
         builder.add_module(SkipModule('A'))
         builder.add_module(
@@ -68,10 +72,11 @@ class TestGraph:
             .depends_on(builder.get_module('C'))
         )
 
-        results = builder.build().run()
-        assert 4 == len(builder.modules)
+        pipeline = await builder.build()
+        assert 4 == len(pipeline.modules)
 
-    def test_should_fail_on_simple_cycle(self):
+    @pytest.mark.asyncio
+    async def test_should_fail_on_simple_cycle(self):
         builder = SequentialPipeline()
         module_a = SkipModule('A')
         module_b = SkipModule('B')
@@ -81,9 +86,10 @@ class TestGraph:
         builder.add_module(module_b)
 
         with pytest.raises(CyclicDependenciesException):
-            results = builder.build().run()
+            await builder.build()
 
-    def test_should_fail_on_long_cycle(self):
+    @pytest.mark.asyncio
+    async def test_should_fail_on_long_cycle(self):
         builder = SequentialPipeline()
         module_a = SkipModule('A')
         module_side_a = SkipModule('side_A')
@@ -120,9 +126,10 @@ class TestGraph:
         builder.add_module(module_side_g)
 
         with pytest.raises(CyclicDependenciesException):
-            results = builder.build().run()
+            await builder.build()
 
-    def test_should_fail_on_multiple_cycles(self):
+    @pytest.mark.asyncio
+    async def test_should_fail_on_multiple_cycles(self):
         builder = SequentialPipeline()
         module_a = SkipModule('A')
         module_side_a = SkipModule('side_A')
@@ -167,4 +174,4 @@ class TestGraph:
         builder.add_module(module_side_g)
 
         with pytest.raises(CyclicDependenciesException):
-            results = builder.build().run()
+            await builder.build()

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -52,16 +52,19 @@ class TestInterfaces:
 
         return os.path.join(__location__, 'test_configs', config_name)
 
-    def test_can_build_pipeline_with_module_accepting_interface(self):
+    @pytest.mark.asyncio
+    async def test_can_build_pipeline_with_module_accepting_interface(self):
         @accept(MockCorrectInterface)
         @finalize
         class ModuleSample(Module.Runtime):
             def run(self, *args, **kwargs):
                 pass
+
         module = ModuleSample('mock')
         builder = SequentialPipeline()
         builder.add_module(module)
-        pipeline = builder.build()
+
+        pipeline = await builder.build()
         assert isinstance(pipeline, SequentialPipeline.Runtime)
 
     def test_cannot_register_interfaces(self):
@@ -122,7 +125,8 @@ class TestInterfaces:
         assert issubclass(ModuleSample._ancestors[0], MockCorrectInterface)
         assert issubclass(ModuleSample._ancestors[1], ModuleClassSample)
 
-    def test_cannot_read_config_with_wrong_all_submodules_interfaces(self):
+    @pytest.mark.asyncio
+    async def test_cannot_read_config_with_wrong_all_submodules_interfaces(self):
         @accept(MockCorrectDependingInterface)
         @finalize
         class ModuleSample(Module.Runtime):
@@ -133,9 +137,10 @@ class TestInterfaces:
         config_file = self.get_config_file('depending_modules_of_invalid_interface.yaml')
         with open(config_file) as config:
             with pytest.raises(Exception):
-                pipeline = ConfigReader.read(config, ModuleFactory)
+                await ConfigReader.read(config, ModuleFactory)
 
-    def test_cannot_read_config_with_wrong_single_submodule_interface(self):
+    @pytest.mark.asyncio
+    async def test_cannot_read_config_with_wrong_single_submodule_interface(self):
         @accept(MockCorrectDependingInterface)
         @finalize
         class ModuleSample(Module.Runtime):
@@ -146,9 +151,10 @@ class TestInterfaces:
         config_file = self.get_config_file('depending_modules_partially_invalid_interface.yaml')
         with open(config_file) as config:
             with pytest.raises(Exception):
-                pipeline = ConfigReader.read(config, ModuleFactory)
+                pipeline = await ConfigReader.read(config, ModuleFactory)
 
-    def test_can_read_config_with_correct_submodule_interfaces(self):
+    @pytest.mark.asyncio
+    async def test_can_read_config_with_correct_submodule_interfaces(self):
         @accept(MockCorrectDependingInterface)
         @finalize
         class ModuleSample(Module.Runtime):
@@ -158,7 +164,7 @@ class TestInterfaces:
         ModuleFactory.register('ModuleSample', ModuleSample)
         config_file = self.get_config_file('depending_modules_of_correct_interface.yaml')
         with open(config_file) as config:
-            pipeline = ConfigReader.read(config, ModuleFactory)
+            pipeline = await ConfigReader.read(config, ModuleFactory)
 
         assert 3 == len(pipeline.modules)
         assert issubclass(pipeline.modules[0].interface, MockCorrectDependingInterface)

--- a/test/test_results.py
+++ b/test/test_results.py
@@ -42,13 +42,13 @@ class TestResults:
         del self.mod_d2
         ModuleFactory.unregister()
 
-    def test_string_results(self):
+    @pytest.mark.asyncio
+    async def test_string_results(self):
         self.builder.add_module(self.mod_c)
         self.builder.add_module(self.mod_d1)
         self.builder.add_module(self.mod_d2.depends_on(self.mod_c).depends_on(self.mod_d1))
-        pipeline = self.builder.build([1, 2, 3])
-        runtime = pipeline.run()
-        print(runtime)
+        pipeline = await self.builder.build([1, 2, 3])
+        runtime = await pipeline.run()
 
         assert runtime['mod_d1'].of('mod_c') == []
         assert runtime['mod_d2'].of('mod_c') == [[1, 2, 3]]
@@ -58,12 +58,13 @@ class TestResults:
         assert len(runtime['mod_d1']) == 0
         assert len(runtime['mod_d2']) == 2
 
-    def test_module_results(self):
+    @pytest.mark.asyncio
+    async def test_module_results(self):
         self.builder.add_module(self.mod_c)
         self.builder.add_module(self.mod_d1)
         self.builder.add_module(self.mod_d2.depends_on(self.mod_c).depends_on(self.mod_d1))
-        pipeline = self.builder.build([1, 2, 3])
-        runtime = pipeline.run()
+        pipeline = await self.builder.build([1, 2, 3])
+        runtime = await pipeline.run()
 
         assert runtime['mod_d1'].of(MockModuleContext) == []
         assert runtime['mod_d2'].of(MockModuleContext) == [[1, 2, 3]]
@@ -71,43 +72,47 @@ class TestResults:
         assert not runtime['mod_d1'].has(MockModuleContext)
         assert runtime['mod_d2'].has(MockModuleContext)
 
-    def test_collection_copy(self):
+    @pytest.mark.asyncio
+    async def test_collection_copy(self):
         self.builder.add_module(self.mod_c)
         self.builder.add_module(self.mod_d1.depends_on(self.mod_c))
-        pipeline = self.builder.build([1, 2, 3])
-        runtime = pipeline.run()
+        pipeline = await self.builder.build([1, 2, 3])
+        runtime = await pipeline.run()
 
         assert runtime['mod_d1'].collection
         assert runtime['mod_d1'].collection is not runtime['mod_d1']._collection
         assert runtime['mod_d1'].collection[0] is runtime['mod_d1']._collection[0]
 
-    def test_module_invalid_has(self):
+    @pytest.mark.asyncio
+    async def test_module_invalid_has(self):
         class InvalidModuleClass():
             pass
 
         self.builder.add_module(self.mod_c)
         self.builder.add_module(self.mod_d1.depends_on(self.mod_c))
-        pipeline = self.builder.build('abc')
-        runtime = pipeline.run()
+        pipeline = await self.builder.build('abc')
+        runtime = await pipeline.run()
 
         assert runtime['mod_d1'].has(MockModuleContext)
         with pytest.raises(KeyError):
             assert runtime['mod_d1'].has(InvalidModuleClass)
 
-    def test_module_invalid_filter_of(self):
+    @pytest.mark.asyncio
+    async def test_module_invalid_filter_of(self):
         class InvalidModuleClass():
             pass
 
         self.builder.add_module(self.mod_c)
         self.builder.add_module(self.mod_d1.depends_on(self.mod_c))
-        pipeline = self.builder.build('abc')
-        runtime = pipeline.run()
+        pipeline = await self.builder.build('abc')
+        runtime = await pipeline.run()
 
         assert runtime['mod_d1'].of(MockModuleContext) == ['abc']
         with pytest.raises(KeyError):
             assert runtime['mod_d1'].of(InvalidModuleClass) == []
 
-    def test_module_invalid_get(self):
+    @pytest.mark.asyncio
+    async def test_module_invalid_get(self):
         self.builder.add_module(self.mod_c)
         self.builder.add_module(self.mod_d1.depends_on(self.mod_c))
         self.builder.add_module(self.mod_d2.depends_on(self.mod_d1))
@@ -116,14 +121,15 @@ class TestResults:
             .depends_on(self.mod_d1)
             .depends_on(self.mod_d2)
         )
-        pipeline = self.builder.build('abc')
-        runtime = pipeline.run()
+        pipeline = await self.builder.build('abc')
+        runtime = await pipeline.run()
 
         assert runtime['mod_d3'].has(MockModuleData)
         with pytest.raises(Exception):
             assert runtime['mod_d3'].get(MockModuleData)
 
-    def test_module_interface_results(self):
+    @pytest.mark.asyncio
+    async def test_module_interface_results(self):
         class MockCorrectInterface(Module.Interface):
             pass
 
@@ -141,8 +147,8 @@ class TestResults:
             MockModuleDataInterface('mod_i2')
             .depends_on(self.builder.get_module('mod_i1'))
         )
-        pipeline = self.builder.build()
-        runtime = pipeline.run()
+        pipeline = await self.builder.build()
+        runtime = await pipeline.run()
 
         assert not runtime['mod_i1'].has(MockCorrectInterface)
         assert runtime['mod_i2'].has(MockCorrectInterface)


### PR DESCRIPTION
**Changes:**
- [x] Added possibility to create async modules (supports both sync/async functions)
- [x] Added possibility to create async bootstrap/teardown method
- [x] Changed default behavior of creating context in `ParallelPipeline` (it's passed untouched instead via `ray.context`)
- [x] Updated tests to handle async pipeline builds/runs
- [x] Updated examples

**Breaking changes:**
- Each pipeline build/run is coroutine now (is awaitable)
- `ConfigReader.read` is also awaitable