### PR TITLE
ConfigReader parameterization

### DIFF
--- a/examples/configs/sample_config_parallel.yaml
+++ b/examples/configs/sample_config_parallel.yaml
@@ -12,6 +12,7 @@ modules:
     group: g2
     depends_on:
       - m2
+
   - name: m4
     type: ModuleA
     group: ${GROUP_M4}

--- a/examples/configs/sample_config_parallel.yaml
+++ b/examples/configs/sample_config_parallel.yaml
@@ -1,0 +1,20 @@
+modules:
+  - name: m1
+    type: ModuleC
+    group: ${GROUP_M1}
+
+  - name: m2
+    type: ModuleB
+    group: g2
+
+  - name: m3
+    type: ModuleB
+    group: g2
+    depends_on:
+      - m2
+  - name: m4
+    type: ModuleA
+    group: ${GROUP_M4}
+    depends_on:
+      - m3
+      - m1

--- a/examples/configs/sample_config_sequential.yaml
+++ b/examples/configs/sample_config_sequential.yaml
@@ -1,0 +1,20 @@
+modules:
+    - name: m1
+      type: ModuleC
+  
+    - name: m2
+      type: ModuleD
+      parameters:
+        threshold: ${THRESHOLD_1}
+  
+    - name: m3
+      type: ModuleD
+      parameters:
+        threshold: ${THRESHOLD_2}
+      depends_on:
+        - m2
+    - name: m4
+      type: ModuleA
+      depends_on:
+        - m3
+        - m1

--- a/examples/configs/sample_config_sequential.yaml
+++ b/examples/configs/sample_config_sequential.yaml
@@ -13,6 +13,7 @@ modules:
         threshold: ${THRESHOLD_2}
       depends_on:
         - m2
+
     - name: m4
       type: ModuleA
       depends_on:

--- a/examples/example4.py
+++ b/examples/example4.py
@@ -1,6 +1,6 @@
-import os
 import asyncio
 from time import time
+from pathlib import Path
 
 from magda.module.factory import ModuleFactory
 from magda.config_reader import ConfigReader
@@ -19,10 +19,7 @@ class ExampleSimpleSequentialConfigReader:
         await example.run()
 
     def get_config_file(self, config_name):
-        __location__ = os.path.realpath(
-            os.path.join(os.getcwd(), os.path.dirname(__file__))
-        )
-        return os.path.join(__location__, 'configs', config_name)
+        return Path(__file__).parent / 'configs' / config_name
 
     async def build(self, prefix: str = '{CTX}'):
         ModuleFactory.register('ModuleA', ModuleA)
@@ -35,7 +32,7 @@ class ExampleSimpleSequentialConfigReader:
             self.pipeline = await ConfigReader.read(
                 config,
                 ModuleFactory,
-                {'THRESHOLD_1': 0.2, 'THRESHOLD_2': 0.2},
+                {'THRESHOLD_1': 0.2, 'THRESHOLD_2': 0.5},
                 context=lambda: Context(prefix)
             )
 

--- a/examples/example4.py
+++ b/examples/example4.py
@@ -1,0 +1,59 @@
+import os
+import asyncio
+from time import time
+
+from magda.module.factory import ModuleFactory
+from magda.config_reader import ConfigReader
+
+from examples.interfaces.common import Request, Context
+from examples.modules.a import ModuleA
+from examples.modules.d import ModuleD
+from examples.modules.c import ModuleC
+
+
+class ExampleSimpleSequentialConfigReader:
+    @classmethod
+    async def demo(cls):
+        example = cls()
+        await example.build()
+        await example.run()
+
+    def get_config_file(self, config_name):
+        __location__ = os.path.realpath(
+            os.path.join(os.getcwd(), os.path.dirname(__file__))
+        )
+        return os.path.join(__location__, 'configs', config_name)
+
+    async def build(self, prefix: str = '{CTX}'):
+        ModuleFactory.register('ModuleA', ModuleA)
+        ModuleFactory.register('ModuleD', ModuleD)
+        ModuleFactory.register('ModuleC', ModuleC)
+
+        config_file = self.get_config_file('sample_config_sequential.yaml')
+        with open(config_file, 'r') as config:
+            config = config.read()
+            self.pipeline = await ConfigReader.read(
+                config,
+                ModuleFactory,
+                {'THRESHOLD_1': 0.2, 'THRESHOLD_2': 0.2},
+                context=lambda: Context(prefix)
+            )
+
+    async def run(self):
+        # Run one job and measure duration
+        start = time()
+        result = await self.pipeline.run(Request('R'))
+        end = time()
+
+        # Close pipeline (and teardown modules)
+        await self.pipeline.close()
+
+        # Print results
+        print(f'Duration = {end - start:.2f} s')
+        print('Results:')
+        for key, value in result.items():
+            print(f'  {key}\t → {value}')
+
+
+if __name__ == "__main__":
+    asyncio.run(ExampleSimpleSequentialConfigReader.demo())

--- a/examples/example5.py
+++ b/examples/example5.py
@@ -1,6 +1,6 @@
-import os
 import asyncio
 from time import time
+from pathlib import Path
 
 from magda.pipeline.parallel import init
 from magda.module.factory import ModuleFactory
@@ -23,10 +23,7 @@ class ExampleParallelConfigReader:
         await example.run()
 
     def get_config_file(self, config_name):
-        __location__ = os.path.realpath(
-            os.path.join(os.getcwd(), os.path.dirname(__file__))
-        )
-        return os.path.join(__location__, 'configs', config_name)
+        return Path(__file__).parent / 'configs' / config_name
 
     async def build(self, prefix: str = '{CTX}'):
         ModuleFactory.register('ModuleA', ModuleA)

--- a/examples/example5.py
+++ b/examples/example5.py
@@ -1,0 +1,71 @@
+import os
+import asyncio
+from time import time
+
+from magda.pipeline.parallel import init
+from magda.module.factory import ModuleFactory
+from magda.config_reader import ConfigReader
+
+from examples.interfaces.common import Context, Request
+from examples.modules.a import ModuleA
+from examples.modules.b import ModuleB
+from examples.modules.c import ModuleC
+
+
+class ExampleParallelConfigReader:
+    def __init__(self):
+        init()
+
+    @classmethod
+    async def demo(cls):
+        example = cls()
+        await example.build()
+        await example.run()
+
+    def get_config_file(self, config_name):
+        __location__ = os.path.realpath(
+            os.path.join(os.getcwd(), os.path.dirname(__file__))
+        )
+        return os.path.join(__location__, 'configs', config_name)
+
+    async def build(self, prefix: str = '{CTX}'):
+        ModuleFactory.register('ModuleA', ModuleA)
+        ModuleFactory.register('ModuleB', ModuleB)
+        ModuleFactory.register('ModuleC', ModuleC)
+
+        config_file = self.get_config_file('sample_config_parallel.yaml')
+        with open(config_file, 'r') as config:
+            config = config.read()
+            self.pipeline = await ConfigReader.read(
+                config,
+                ModuleFactory,
+                {'GROUP_M1': 'g1', 'GROUP_M4': 'g3'},
+                context=lambda: Context(prefix)
+            )
+
+    async def run(self, value: str = 'R', n_jobs: int = 3):
+        # Run jobs and measure duration
+        start = time()
+        results = await asyncio.gather(*[
+            asyncio.create_task(
+                self.pipeline.run(Request(value=f'{value}{i}'))
+            )
+            for i in range(n_jobs)
+        ])
+        end = time()
+
+        # Close pipeline and teardown modules
+        await self.pipeline.close()
+        await asyncio.sleep(0.5)
+
+        # Print results
+        print(f'Duration = {end - start:.2f} s')
+        print('Results:')
+        for index, result in enumerate(results):
+            print(f' {index}:')
+            for key, value in result.items():
+                print(f'  {key}\t → {value}')
+
+
+if __name__ == "__main__":
+    asyncio.run(ExampleParallelConfigReader.demo())

--- a/examples/modules/d.py
+++ b/examples/modules/d.py
@@ -18,7 +18,7 @@ class ModuleD(Module.Runtime):
     def bootstrap(self):
         ctx: Context = self.context
         log(self, ctx.timer, '--- Created!')
-        log(self, ctx.timer, self.parameters['threshold'])
+        log(self, ctx.timer, f"- Threshold = {self.parameters['threshold']}")
 
     def teardown(self):
         ctx: Context = self.context

--- a/examples/modules/d.py
+++ b/examples/modules/d.py
@@ -1,0 +1,43 @@
+import asyncio
+
+from magda.module import Module
+from magda.decorators import register, accept, finalize, produce
+
+from examples.modules.common import log
+from examples.interfaces.common import Context
+from examples.interfaces.fn import LambdaInterface
+
+
+@accept(LambdaInterface)
+@produce(LambdaInterface)
+@register('D')
+@finalize
+class ModuleD(Module.Runtime):
+    SLEEP_TIME = 1
+
+    def bootstrap(self):
+        ctx: Context = self.context
+        log(self, ctx.timer, '--- Created!')
+        log(self, ctx.timer, self.parameters['threshold'])
+
+    def teardown(self):
+        ctx: Context = self.context
+        log(self, ctx.timer, '--- Teardown!')
+
+    async def run(self, data: Module.ResultSet, *args, **kwargs):
+        # Mark module's start
+        ctx: Context = self.context
+        log(self, ctx.timer, '- Start')
+
+        # Access strings (results) from the previous modules
+        src = [text.fn() for text in data.of(LambdaInterface)]
+
+        # E.g. some IO operation (delay for example purposes)
+        await asyncio.sleep(self.SLEEP_TIME)
+
+        # Mark module's end
+        log(self, ctx.timer, '- End')
+
+        # Build output string and produce declared interface
+        msg = '(' + ' + '.join(src) + (' = ' if len(src) else '') + f'{self.name})'
+        return LambdaInterface(lambda: msg)

--- a/magda/config_reader.py
+++ b/magda/config_reader.py
@@ -8,8 +8,8 @@ from numbers import Number
 from magda.module.factory import ModuleFactory
 from magda.pipeline.sequential import SequentialPipeline
 from magda.pipeline.parallel.parallel_pipeline import ParallelPipeline
-from magda.exceptions import WrongParametersStructureException, \
-    WrongParameterValueException, ConfiguartionFileException
+from magda.exceptions import (WrongParametersStructureException,
+                              WrongParameterValueException, ConfiguartionFileException)
 
 
 class ConfigReader:

--- a/magda/exceptions.py
+++ b/magda/exceptions.py
@@ -13,11 +13,16 @@ class ClosedPipelineException(Exception):
         super().__init__('The pipeline was closed and cannot be run')
 
 
-class WrongParameterStructureException(Exception):
+class WrongParametersStructureException(Exception):
     def __init__(self, message):
         super().__init__(message)
 
 
-class ParametrizationException(Exception):
+class WrongParameterValueException(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class ConfiguartionFileException(Exception):
     def __init__(self, message):
         super().__init__(message)

--- a/magda/exceptions.py
+++ b/magda/exceptions.py
@@ -11,3 +11,13 @@ class DisjointGraphException(Exception):
 class ClosedPipelineException(Exception):
     def __init__(self):
         super().__init__('The pipeline was closed and cannot be run')
+
+
+class WrongParameterStructureException(Exception):
+    def __init__(self, message):
+        super().__init__(message)
+
+
+class ParametrizationException(Exception):
+    def __init__(self, message):
+        super().__init__(message)

--- a/magda/exceptions.py
+++ b/magda/exceptions.py
@@ -14,15 +14,12 @@ class ClosedPipelineException(Exception):
 
 
 class WrongParametersStructureException(Exception):
-    def __init__(self, message):
-        super().__init__(message)
+    pass
 
 
 class WrongParameterValueException(Exception):
-    def __init__(self, message):
-        super().__init__(message)
+    pass
 
 
 class ConfiguartionFileException(Exception):
-    def __init__(self, message):
-        super().__init__(message)
+    pass

--- a/test/test_config_reader.py
+++ b/test/test_config_reader.py
@@ -1,0 +1,101 @@
+import os
+import pytest
+
+from magda.module.module import Module
+from magda.module.factory import ModuleFactory
+from magda.module.interface import ModuleInterface
+from magda.pipeline.sequential import SequentialPipeline
+from magda.config_reader import ConfigReader
+from magda.decorators import finalize
+from magda.decorators.accepting import accept
+from magda.decorators.producing import produce
+from magda.exceptions import WrongParameterStructureException
+
+
+class MockCorrectDependingInterface(ModuleInterface):
+    pass
+
+
+class TestConfigReader:
+
+    def setup_method(self, method):
+        @produce(MockCorrectDependingInterface)
+        @finalize
+        class ModuleDependingCorrect(Module.Runtime):
+            def run(self, *args, **kwargs):
+                pass
+
+        ModuleFactory.unregister()
+        ModuleFactory.register('ModuleDependingCorrect', ModuleDependingCorrect)
+
+    def teardown_method(self, method):
+        ModuleFactory.unregister()
+
+    def get_config_file(self, config_name):
+        __location__ = os.path.realpath(
+            os.path.join(os.getcwd(), os.path.dirname(__file__))
+        )
+
+        return os.path.join(__location__, 'test_configs', config_name)
+
+    @pytest.mark.asyncio
+    async def test_should_not_read_config_parameters_with_nested_structure(self):
+        config_file = self.get_config_file('depending_modules_of_correct_interface.yaml')
+        incorrect_parameters = {'ARG1': 'correct', 'ARG2': {'ARG3': 'incorrect'}}
+
+        with open(config_file) as config:
+            with pytest.raises(WrongParameterStructureException):
+                await ConfigReader.read(config, ModuleFactory, incorrect_parameters)
+
+    @pytest.mark.asyncio
+    async def test_should_not_read_config_parameters_with_incorrect_values(self):
+        config_file = self.get_config_file('depending_modules_of_correct_interface.yaml')
+
+        incorrect_parameters = {'ARG1': 'correct', 'ARG2': MockCorrectDependingInterface}
+        with open(config_file) as config:
+            with pytest.raises(WrongParameterStructureException):
+                await ConfigReader.read(config, ModuleFactory, incorrect_parameters)
+
+    @pytest.mark.asyncio
+    async def test_should_not_read_config_parameters_other_than_dictionary(self):
+        config_file = self.get_config_file('depending_modules_of_correct_interface.yaml')
+
+        incorrect_parameters = [{'ARG1': 'value1'}, {'ARG2': 'value2'}]
+        with open(config_file) as config:
+            with pytest.raises(WrongParameterStructureException):
+                await ConfigReader.read(config, ModuleFactory, incorrect_parameters)
+
+    @pytest.mark.asyncio
+    async def test_should_not_read_config_parameters_with_wrong_dict_keys(self):
+        config_file = self.get_config_file('depending_modules_of_correct_interface.yaml')
+
+        incorrect_parameters = {MockCorrectDependingInterface: 'value1', 2: 'value2'}
+        with open(config_file) as config:
+            with pytest.raises(WrongParameterStructureException):
+                await ConfigReader.read(config, ModuleFactory, incorrect_parameters)
+
+    @pytest.mark.asyncio
+    async def test_should_pass_with_correct_variables_in_config(self):
+        @accept(MockCorrectDependingInterface)
+        @finalize
+        class ModuleSample(Module.Runtime):
+            pass
+
+        ModuleFactory.register('ModuleSample', ModuleSample)
+
+        config_file = self.get_config_file('correctly_parametrized_config.yaml')
+
+        correct_parameters = {
+            'TYPE_1': 'ModuleDependingCorrect',
+            'NAME_2': 'mod2',
+            'THRESHOLD': 0.2,
+            'BIAS': 0.1
+        }
+
+        with open(config_file) as config:
+            pipeline = await ConfigReader.read(config_file, ModuleFactory, correct_parameters)
+
+        assert 3 == len(pipeline.modules)
+        assert issubclass(pipeline.modules[0].interface, MockCorrectDependingInterface)
+        assert issubclass(pipeline.modules[1].interface, MockCorrectDependingInterface)
+        assert pipeline.modules[2].input_modules == ['mod1', 'mod2']

--- a/test/test_config_reader.py
+++ b/test/test_config_reader.py
@@ -9,7 +9,8 @@ from magda.config_reader import ConfigReader
 from magda.decorators import finalize
 from magda.decorators.accepting import accept
 from magda.decorators.producing import produce
-from magda.exceptions import WrongParameterStructureException
+from magda.exceptions import WrongParametersStructureException, \
+    WrongParameterValueException, ConfiguartionFileException
 
 
 class MockCorrectDependingInterface(ModuleInterface):
@@ -44,7 +45,7 @@ class TestConfigReader:
         incorrect_parameters = {'ARG1': 'correct', 'ARG2': {'ARG3': 'incorrect'}}
 
         with open(config_file) as config:
-            with pytest.raises(WrongParameterStructureException):
+            with pytest.raises(WrongParameterValueException):
                 await ConfigReader.read(config, ModuleFactory, incorrect_parameters)
 
     @pytest.mark.asyncio
@@ -53,7 +54,7 @@ class TestConfigReader:
 
         incorrect_parameters = {'ARG1': 'correct', 'ARG2': MockCorrectDependingInterface}
         with open(config_file) as config:
-            with pytest.raises(WrongParameterStructureException):
+            with pytest.raises(WrongParameterValueException):
                 await ConfigReader.read(config, ModuleFactory, incorrect_parameters)
 
     @pytest.mark.asyncio
@@ -62,7 +63,7 @@ class TestConfigReader:
 
         incorrect_parameters = [{'ARG1': 'value1'}, {'ARG2': 'value2'}]
         with open(config_file) as config:
-            with pytest.raises(WrongParameterStructureException):
+            with pytest.raises(WrongParametersStructureException):
                 await ConfigReader.read(config, ModuleFactory, incorrect_parameters)
 
     @pytest.mark.asyncio
@@ -71,7 +72,8 @@ class TestConfigReader:
 
         incorrect_parameters = {MockCorrectDependingInterface: 'value1', 2: 'value2'}
         with open(config_file) as config:
-            with pytest.raises(WrongParameterStructureException):
+            config = config.read()
+            with pytest.raises(WrongParameterValueException):
                 await ConfigReader.read(config, ModuleFactory, incorrect_parameters)
 
     @pytest.mark.asyncio
@@ -89,13 +91,36 @@ class TestConfigReader:
             'TYPE_1': 'ModuleDependingCorrect',
             'NAME_2': 'mod2',
             'THRESHOLD': 0.2,
-            'BIAS': 0.1
+            'BIAS': 0.1,
+            'group_name': 'group1'
         }
 
         with open(config_file) as config:
-            pipeline = await ConfigReader.read(config_file, ModuleFactory, correct_parameters)
+            config = config.read()
+            pipeline = await ConfigReader.read(config, ModuleFactory, correct_parameters)
 
         assert 3 == len(pipeline.modules)
         assert issubclass(pipeline.modules[0].interface, MockCorrectDependingInterface)
         assert issubclass(pipeline.modules[1].interface, MockCorrectDependingInterface)
         assert pipeline.modules[2].input_modules == ['mod1', 'mod2']
+
+    @pytest.mark.asyncio
+    async def test_should_not_pass_with_redundant_variables_in_config(self):
+        config_file_with_redundant_vars = self.get_config_file(
+            'incorrectly_parametrized_config.yaml'
+        )
+
+        correct_parameters = {
+            'TYPE_1': 'ModuleDependingCorrect',
+            'NAME_2': 'mod2',
+            'THRESHOLD': 0.2
+        }
+
+        with open(config_file_with_redundant_vars) as config:
+            config = config.read()
+            with pytest.raises(ConfiguartionFileException):
+                await ConfigReader.read(
+                    config,
+                    ModuleFactory,
+                    correct_parameters
+                )

--- a/test/test_configs/correctly_parametrized_config.yaml
+++ b/test/test_configs/correctly_parametrized_config.yaml
@@ -1,0 +1,15 @@
+modules:
+  - name: ${NAME_2}
+    type: ModuleDependingCorrect
+
+  - name: mod1
+    type: ${TYPE_1}
+
+  - name: mod0
+    type: ModuleSample
+    depends_on:
+      - mod1
+      - mod2
+    parameters:
+      threshold : ${THRESHOLD}
+      threshold2 : ${THRESHOLD}

--- a/test/test_configs/correctly_parametrized_config.yaml
+++ b/test/test_configs/correctly_parametrized_config.yaml
@@ -13,3 +13,11 @@ modules:
     parameters:
       threshold : ${THRESHOLD}
       threshold2 : ${THRESHOLD}
+
+shared_parameters:
+  threshold: ${THRESHOLD}
+
+groups:
+  - name: ${group_name}
+    options:
+      replicas: 3

--- a/test/test_configs/correctly_parametrized_config.yaml
+++ b/test/test_configs/correctly_parametrized_config.yaml
@@ -1,6 +1,6 @@
 modules:
   - name: ${NAME_2}
-    type: ModuleDependingCorrect
+    type: DependingModule
 
   - name: mod1
     type: ${TYPE_1}

--- a/test/test_configs/incorrectly_parametrized_config.yaml
+++ b/test/test_configs/incorrectly_parametrized_config.yaml
@@ -1,0 +1,12 @@
+modules:
+  - name: mod2
+    type: ModuleDependingCorrect
+
+  - name: mod1
+    type: ModuleDependingCorrect
+
+  - name: mod0
+    type: ModuleSample
+    depends_on:
+      - mod1
+      - mod2

--- a/test/test_configs/incorrectly_parametrized_config.yaml
+++ b/test/test_configs/incorrectly_parametrized_config.yaml
@@ -1,9 +1,9 @@
 modules:
   - name: ${NAME_2}
-    type: ModuleDependingCorrect
+    type: ModuleSample
 
   - name: mod1
-    type: ${TYPE_1}
+    type: ModuleSample
 
   - name: mod0
     type: ModuleSample

--- a/test/test_configs/incorrectly_parametrized_config.yaml
+++ b/test/test_configs/incorrectly_parametrized_config.yaml
@@ -1,12 +1,16 @@
 modules:
-  - name: mod2
+  - name: ${NAME_2}
     type: ModuleDependingCorrect
 
   - name: mod1
-    type: ModuleDependingCorrect
+    type: ${TYPE_1}
 
   - name: mod0
     type: ModuleSample
     depends_on:
       - mod1
       - mod2
+    parameters:
+      threshold : ${THRESHOLD}
+      threshold2 : ${THRESHOLD}
+      learning_rate : ${LEARNING_RATE}

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -1,5 +1,5 @@
-import os
 import pytest
+from pathlib import Path
 
 from magda.module.module import Module
 from magda.module.factory import ModuleFactory
@@ -46,11 +46,7 @@ class TestInterfaces:
         ModuleFactory.unregister()
 
     def get_config_file(self, config_name):
-        __location__ = os.path.realpath(
-            os.path.join(os.getcwd(), os.path.dirname(__file__))
-        )
-
-        return os.path.join(__location__, 'test_configs', config_name)
+        return Path(__file__).parent / 'test_configs' / config_name
 
     @pytest.mark.asyncio
     async def test_can_build_pipeline_with_module_accepting_interface(self):

--- a/test/test_interfaces.py
+++ b/test/test_interfaces.py
@@ -132,6 +132,7 @@ class TestInterfaces:
 
         config_file = self.get_config_file('depending_modules_of_invalid_interface.yaml')
         with open(config_file) as config:
+            config = config.read()
             with pytest.raises(Exception):
                 await ConfigReader.read(config, ModuleFactory)
 
@@ -146,6 +147,7 @@ class TestInterfaces:
 
         config_file = self.get_config_file('depending_modules_partially_invalid_interface.yaml')
         with open(config_file) as config:
+            config = config.read()
             with pytest.raises(Exception):
                 pipeline = await ConfigReader.read(config, ModuleFactory)
 
@@ -160,6 +162,7 @@ class TestInterfaces:
         ModuleFactory.register('ModuleSample', ModuleSample)
         config_file = self.get_config_file('depending_modules_of_correct_interface.yaml')
         with open(config_file) as config:
+            config = config.read()
             pipeline = await ConfigReader.read(config, ModuleFactory)
 
         assert 3 == len(pipeline.modules)


### PR DESCRIPTION
What?
We would like to parameterize config files of pipeline declaration (similar to parameterizing docker-compose.yml with environment variables)

Why?
Sometimes you would like to run the same pipeline with just a different parameter. In this situation you have to modify the config or duplicate it (which is impractical).

How?
By updating ConfigReader to accept an optional dictionary of parameters and replacing all placeholders within the config file with an appropriate value from the provided dictionary.

@jamebs @p-mielniczuk  @mmaslankowska-neurosys 