### PR TITLE
Issue #12 Testing modules solved.

### DIFF
--- a/magda/testing/__init__.py
+++ b/magda/testing/__init__.py
@@ -1,0 +1,1 @@
+from .module_testing_wrapper import ModuleTestingWrapper

--- a/magda/testing/module_testing_wrapper.py
+++ b/magda/testing/module_testing_wrapper.py
@@ -1,32 +1,45 @@
-from typing import List
-from inspect import signature
+from __future__ import annotations
+from typing import Any
 
-from magda.testing.utils import wrap_data_into_resultset, call_async_or_sync_func
+from magda.module.results import ResultSet
 from magda.module.runtime import ModuleRuntime
+from magda.testing.utils import wrap_into_result, call_async_or_sync_func
 
 
 class ModuleTestingWrapper:
     def __init__(self, module: ModuleRuntime):
         self.module: ModuleRuntime = module
+        self._request: Any = None
+        self._data: ResultSet = None
 
     async def build(self, shared_parameters={}, context=None, call_bootstrap=True):
-        self.module = await call_async_or_sync_func(self.module.build, context=context, shared_parameters=shared_parameters)
+        self.module = await call_async_or_sync_func(
+            self.module.build,
+            context=context,
+            shared_parameters=shared_parameters
+        )
 
         if call_bootstrap:
             await call_async_or_sync_func(self.module.bootstrap)
 
         return self
 
-    async def run(self, *args, **kwargs):
-        arg_names = self._get_module_run_method_arg_names()
-        args, kwargs = wrap_data_into_resultset(arg_names, *args, **kwargs)
-        results = await call_async_or_sync_func(self.module.run, *args, **kwargs)
+    def request(self, request: Any) -> ModuleTestingWrapper:
+        self._request = request
+        return self
+
+    def data(self, *data) -> ModuleTestingWrapper:
+        results = list(map(wrap_into_result, data))
+        self._data = ResultSet(results)
+        return self
+
+    async def run(self):
+        results = await call_async_or_sync_func(
+            self.module.run,
+            data=self._data,
+            request=self._request
+        )
         return results
 
     async def close(self):
         await call_async_or_sync_func(self.module.teardown)
-
-    def _get_module_run_method_arg_names(self) -> List[str]:
-        sig = signature(self.module.run)
-        return list(sig.parameters.keys())
-

--- a/magda/testing/module_testing_wrapper.py
+++ b/magda/testing/module_testing_wrapper.py
@@ -1,0 +1,32 @@
+from typing import List
+from inspect import signature
+
+from magda.testing.utils import wrap_data_into_resultset, call_async_or_sync_func
+from magda.module.runtime import ModuleRuntime
+
+
+class ModuleTestingWrapper:
+    def __init__(self, module: ModuleRuntime):
+        self.module: ModuleRuntime = module
+
+    async def build(self, shared_parameters={}, context=None, call_bootstrap=True):
+        self.module = await call_async_or_sync_func(self.module.build, context=context, shared_parameters=shared_parameters)
+
+        if call_bootstrap:
+            await call_async_or_sync_func(self.module.bootstrap)
+
+        return self
+
+    async def run(self, *args, **kwargs):
+        arg_names = self._get_module_run_method_arg_names()
+        args, kwargs = wrap_data_into_resultset(arg_names, *args, **kwargs)
+        results = await call_async_or_sync_func(self.module.run, *args, **kwargs)
+        return results
+
+    async def close(self):
+        await call_async_or_sync_func(self.module.teardown)
+
+    def _get_module_run_method_arg_names(self) -> List[str]:
+        sig = signature(self.module.run)
+        return list(sig.parameters.keys())
+

--- a/magda/testing/utils.py
+++ b/magda/testing/utils.py
@@ -1,0 +1,40 @@
+import asyncio
+from typing import List, Tuple, Callable
+
+from magda.module import Module
+
+
+def wrap_into_result(result, name='', src_class=None, expose=None):
+    interface = result.__class__
+    return Module.Result(result=result, interface=interface, name=name, src_class=src_class, expose=expose)
+
+
+def wrap_single_object_into_resultset(obj, name='', src_class=None, expose=None):
+    result = wrap_into_result(result=obj, name=name, src_class=src_class, expose=expose)
+    return Module.ResultSet([result])
+
+
+def wrap_data_into_resultset(arg_names: List[str], *args, **kwargs) -> Tuple[tuple, dict]:
+    """
+    Inspects given arguments and wraps argument called 'data' into Module.ResultSet.
+    """    
+    if 'data' in kwargs:
+        kwargs['data'] = wrap_single_object_into_resultset(kwargs['data'])
+        return args, kwargs
+
+    if 'data' in arg_names:
+        remaining_arg_names = list(filter(lambda x: x not in kwargs.keys(), arg_names))
+        data_index = remaining_arg_names.index('data')
+        args_list = list(args)
+        args_list[data_index] = wrap_single_object_into_resultset(args_list[data_index])
+        return tuple(args_list), kwargs
+
+    # run does not expect 'data' argument and it has not been given
+    return args, kwargs
+
+
+async def call_async_or_sync_func(func: Callable, *args, **kwargs):
+    if asyncio.iscoroutinefunction(func):
+        return await func(*args, **kwargs)
+    else:
+        return func(*args, **kwargs)

--- a/magda/testing/utils.py
+++ b/magda/testing/utils.py
@@ -4,7 +4,7 @@ from typing import Callable
 from magda.module import Module
 
 
-def wrap_into_result(result, name='', src_class=None, expose=None):
+def wrap_into_result(result, name='testing-module', src_class=None, expose=None):
     interface = result.__class__
     return Module.Result(
         result=result,

--- a/magda/testing/utils.py
+++ b/magda/testing/utils.py
@@ -1,36 +1,18 @@
 import asyncio
-from typing import List, Tuple, Callable
+from typing import Callable
 
 from magda.module import Module
 
 
 def wrap_into_result(result, name='', src_class=None, expose=None):
     interface = result.__class__
-    return Module.Result(result=result, interface=interface, name=name, src_class=src_class, expose=expose)
-
-
-def wrap_single_object_into_resultset(obj, name='', src_class=None, expose=None):
-    result = wrap_into_result(result=obj, name=name, src_class=src_class, expose=expose)
-    return Module.ResultSet([result])
-
-
-def wrap_data_into_resultset(arg_names: List[str], *args, **kwargs) -> Tuple[tuple, dict]:
-    """
-    Inspects given arguments and wraps argument called 'data' into Module.ResultSet.
-    """    
-    if 'data' in kwargs:
-        kwargs['data'] = wrap_single_object_into_resultset(kwargs['data'])
-        return args, kwargs
-
-    if 'data' in arg_names:
-        remaining_arg_names = list(filter(lambda x: x not in kwargs.keys(), arg_names))
-        data_index = remaining_arg_names.index('data')
-        args_list = list(args)
-        args_list[data_index] = wrap_single_object_into_resultset(args_list[data_index])
-        return tuple(args_list), kwargs
-
-    # run does not expect 'data' argument and it has not been given
-    return args, kwargs
+    return Module.Result(
+        result=result,
+        interface=interface,
+        name=name,
+        src_class=src_class,
+        expose=expose
+    )
 
 
 async def call_async_or_sync_func(func: Callable, *args, **kwargs):

--- a/test/test_module_testing_wrapper.py
+++ b/test/test_module_testing_wrapper.py
@@ -1,12 +1,10 @@
 from dataclasses import dataclass
-from typing import Any, Tuple
-from unittest.mock import MagicMock
+from typing import Dict
 
 import pytest
 
 from magda.decorators import accept, produce, finalize
 from magda.module import Module
-from magda.module.results import ResultSet
 from magda.testing import ModuleTestingWrapper
 
 
@@ -26,19 +24,24 @@ class ProcessedData(Module.Interface):
 @accept(RawData)
 @produce(ProcessedData)
 @finalize
+class ModuleTakingRequestAndData(Module.Runtime):
+    def run(self, request, data: Module.ResultSet, **kwargs):
+        return ProcessedData(data.get(RawData)[::-1] + ' ' + request['text'])
+
+
+@accept(RawData)
+@produce(ProcessedData)
+@finalize
 class ModuleOnlyData(Module.Runtime):
-    """
-    Module has only 'data' argument in method run(). It is typical, expected use case.
-    """
-    @dataclass
-    class Parameters:
-        param: str
-
-    def bootstrap(self, **kwargs):
-        self.params: self.Parameters = self.Parameters(**self.parameters)
-
     def run(self, data: Module.ResultSet, **kwargs):
         return ProcessedData(data.get(RawData)[::-1])
+
+
+@produce(ProcessedData)
+@finalize
+class ModuleOnlyRequest(Module.Runtime):
+    def run(self, request: Dict[str, str], **kwargs):
+        return ProcessedData(request['text'])
 
 
 @accept(RawData, ProcessedData)
@@ -48,6 +51,14 @@ class ModuleManyDataElements(Module.Runtime):
     """
     Module takes 'data' argument which is ResultSet with many elements.
     """
+    def run(self, data: Module.ResultSet, **kwargs):
+        text_part_1 = data.get(RawData)[::-1]
+        text_part_2 = data.get(ProcessedData).data
+        return ProcessedData(text_part_1 + '_' + text_part_2)
+
+
+@finalize
+class ModuleTestForSettingParameters(Module.Runtime):
     @dataclass
     class Parameters:
         param: str
@@ -56,92 +67,64 @@ class ModuleManyDataElements(Module.Runtime):
         self.params: self.Parameters = self.Parameters(**self.parameters)
 
     def run(self, data: Module.ResultSet, **kwargs):
-        text_part_1 = data.get(RawData)[::-1]
-        text_part_2 = data.get(ProcessedData).data
-        return ProcessedData(text_part_1 + '_' + text_part_2)
+        return ProcessedData(data.get(RawData)[::-1])
 
 
-@accept(RawData)
-@produce(ProcessedData)
 @finalize
 class ModuleSync(Module.Runtime):
-    @dataclass
-    class Parameters:
-        param: str
-
     def bootstrap(self, **kwargs):
         self.is_built: bool = True
-        self.params: self.Parameters = self.Parameters(**self.parameters)
+        self.is_run: bool = False
 
     def run(self, request, data: Module.ResultSet, **kwargs):
-        self.request = request
-        self.data = data
-        return ProcessedData(data.get(RawData)[::-1])
+        self.is_run = True
+        return None
 
     def teardown(self):
         self.is_built: bool = False
         return super().teardown()
 
 
-@accept(RawData)
-@produce(ProcessedData)
 @finalize
 class ModuleAsync(Module.Runtime):
-    @dataclass
-    class Parameters:
-        param: str
-
     async def bootstrap(self, **kwargs):
         self.is_built: bool = True
-        self.params: self.Parameters = self.Parameters(**self.parameters)
+        self.is_run: bool = False
 
     async def run(self, request, data: Module.ResultSet, **kwargs):
-        return ProcessedData(data.get(RawData)[::-1])
+        self.is_run = True
+        return None
 
     async def teardown(self):
         self.is_built: bool = False
         return super().teardown()
 
 
-def run_mock_sync(self, request, data, **kwargs) -> Tuple[Any, Any]:
-    return request, data
-
-
-async def run_mock_async(self, request, data, **kwargs) -> Tuple[Any, Any]:
-    return request, data
-
-
-@pytest.mark.parametrize('module_cls', [ModuleAsync, ModuleSync])
 @pytest.mark.asyncio
 class TestModuleTestingWrapper:
     module_params = {'param': 'value'}
 
-    async def test_should_process_correctly(self, module_cls):
-        module = module_cls('my-module-a').set_parameters(TestModuleTestingWrapper.module_params)
-        mock = await ModuleTestingWrapper(module).build()
-
-        result = await mock.data(RawData('xyz')).request({'query': 'query'}).run()
-        assert result == ProcessedData('zyx')
-
-    async def test_should_process_correctly_many_data_elements(self, module_cls):
-        module = module_cls('my-module-a').set_parameters(TestModuleTestingWrapper.module_params)
-        mock = await ModuleTestingWrapper(module).build()
-
-        result = await mock.data(RawData('xyz')).request({'query': 'query'}).run()
-        assert result == ProcessedData('zyx')
-
+    @pytest.mark.parametrize('module_cls', [ModuleAsync, ModuleSync])
     async def test_should_correctly_bootstrap(self, module_cls):
-        module = module_cls('my-module-a').set_parameters(TestModuleTestingWrapper.module_params)
+        module = module_cls('test-module')
         mock = await ModuleTestingWrapper(module).build()
         assert mock.module.is_built
 
+    @pytest.mark.parametrize('module_cls', [ModuleAsync, ModuleSync])
     async def test_should_correctly_teardown(self, module_cls):
-        module = module_cls('my-module-a').set_parameters(TestModuleTestingWrapper.module_params)
+        module = module_cls('test-module')
         mock = await ModuleTestingWrapper(module).build()
         await mock.close()
         assert not mock.module.is_built
 
-    async def test_should_correctly_set_request(self, module_cls):
+    @pytest.mark.parametrize('module_cls', [ModuleAsync, ModuleSync])
+    async def test_should_correctly_invoke_run(self, module_cls):
+        module = module_cls('test-module')
+        mock = await ModuleTestingWrapper(module).build()
+        await mock.run()
+        assert mock.module.is_run
+
+    async def test_should_correctly_set_request(self):
         target_request = {'key': 'value'}
 
         @finalize
@@ -154,7 +137,7 @@ class TestModuleTestingWrapper:
         mock = mock.request(target_request)
         await mock.run()
 
-    async def test_should_correctly_set_data(self, module_cls):
+    async def test_should_correctly_set_data(self):
         raw_data = RawData('xyz')
 
         @finalize
@@ -167,44 +150,58 @@ class TestModuleTestingWrapper:
         mock = mock.data(raw_data)
         await mock.run()
 
-    async def test_should_not_compile(self, module_cls):
-        module = module_cls('my-module-a').set_parameters({})   # Missing required params
+    async def test_should_correctly_process_request_and_data(self):
+        module = ModuleTakingRequestAndData('test-module')
+        mock = await ModuleTestingWrapper(module).build()
 
-        with pytest.raises(TypeError):
-            await ModuleTestingWrapper(module).build()
+        result = await mock.request({'text': 'request_text'}).data(RawData('xyz')).run()
+        assert result == ProcessedData('zyx request_text')
 
-    async def test_should_correctly_pass_shared_parameters(self, module_cls):
-        shared_parameters = {'shared_param': 'value'}
-        module = module_cls('my-module-a').set_parameters(TestModuleTestingWrapper.module_params)
-        mock = await ModuleTestingWrapper(module).build(shared_parameters=shared_parameters)
-        assert mock.module.shared_parameters == shared_parameters
-
-    async def test_should_correctly_pass_context(self, module_cls):
-        def get_context():
-            return 'callable context'
-
-        module = module_cls('my-module-a').set_parameters(TestModuleTestingWrapper.module_params)
-        mock = await ModuleTestingWrapper(module).build(context=get_context)
-        assert mock.module.context() == get_context()
-
-
-class TestModuleTestingWrapperOnlyData:
-    @pytest.mark.asyncio
-    async def test_should_process_correctly(self):
-        module = ModuleOnlyData('my-module-a').set_parameters({'param': 'value'})
+    async def test_should_correctly_process_only_data(self):
+        module = ModuleOnlyData('test-module')
         mock = await ModuleTestingWrapper(module).build()
 
         mock = mock.data(RawData('xyz'))
         result = await mock.run()
         assert result == ProcessedData('zyx')
 
+    async def test_should_correctly_process_only_request(self):
+        module = ModuleOnlyRequest('test-module')
+        mock = await ModuleTestingWrapper(module).build()
 
-class TestModuleTestingWrapperManyDataElements:
-    @pytest.mark.asyncio
-    async def test_should_process_correctly(self):
-        module = ModuleManyDataElements('my-module-a').set_parameters({'param': 'value'})
+        mock = mock.request({'text': 'request_text'})
+        result = await mock.run()
+        assert result == ProcessedData('request_text')
+
+    async def test_should_correctly_process_many_data_elements(self):
+        module = ModuleManyDataElements('test-module')
         mock = await ModuleTestingWrapper(module).build()
 
         mock = mock.data(RawData('xyz'), ProcessedData('xyz'))
         result = await mock.run()
         assert result == ProcessedData('zyx_xyz')
+
+    async def test_should_build_when_parameters_are_passed(self):
+        module = ModuleTestForSettingParameters('test-module').set_parameters({'param': 'value'})
+        mock = await ModuleTestingWrapper(module).build()
+        assert isinstance(mock, ModuleTestingWrapper)
+
+    async def test_should_not_build_for_empty_parameters(self):
+        module = ModuleTestForSettingParameters('test-module').set_parameters({})
+
+        with pytest.raises(TypeError):
+            await ModuleTestingWrapper(module).build()
+
+    async def test_should_correctly_pass_shared_parameters(self):
+        shared_parameters = {'shared_param': 'value'}
+        module = ModuleSync('test-module')
+        mock = await ModuleTestingWrapper(module).build(shared_parameters=shared_parameters)
+        assert mock.module.shared_parameters == shared_parameters
+
+    async def test_should_correctly_pass_context(self):
+        def get_context():
+            return 'callable context'
+
+        module = ModuleSync('test-module')
+        mock = await ModuleTestingWrapper(module).build(context=get_context)
+        assert mock.module.context() == get_context()

--- a/test/test_module_testing_wrapper.py
+++ b/test/test_module_testing_wrapper.py
@@ -1,0 +1,187 @@
+from dataclasses import dataclass
+
+import pytest
+
+from magda.testing import ModuleTestingWrapper
+from magda.decorators import accept, produce, finalize
+from magda.module import Module
+from magda.testing.utils import wrap_data_into_resultset, wrap_into_result, wrap_single_object_into_resultset
+
+
+@dataclass(frozen=True)
+class RawData(Module.Interface):
+    data: str
+
+    def __getitem__(self, index):
+        return self.data[index]
+
+
+@dataclass(frozen=True)
+class ProcessedData(Module.Interface):
+    data: str
+
+
+@accept(RawData)
+@produce(ProcessedData)
+@finalize
+class ModuleOnlyData(Module.Runtime):
+    """
+    Module has only 'data' argument in method run(). It is typical, expected use case.
+    """
+    @dataclass
+    class Parameters:
+        param: str
+
+    def bootstrap(self, **kwargs):
+        self.params: self.Parameters = self.Parameters(**self.parameters)
+
+    def run(self, data: Module.ResultSet, **kwargs):
+        return ProcessedData(data.get(RawData)[::-1])
+
+
+@accept(RawData)
+@produce(ProcessedData)
+@finalize
+class ModuleSync(Module.Runtime):
+    @dataclass
+    class Parameters:
+        param: str
+
+    def bootstrap(self, **kwargs):
+        self.is_built: bool = True
+        self.params: self.Parameters = self.Parameters(**self.parameters)
+
+    def run(self, request, data: Module.ResultSet, **kwargs):
+        return ProcessedData(data.get(RawData)[::-1])
+
+    def teardown(self):
+        self.is_built: bool = False
+        return super().teardown()
+
+
+@accept(RawData)
+@produce(ProcessedData)
+@finalize
+class ModuleAsync(Module.Runtime):
+    @dataclass
+    class Parameters:
+        param: str
+
+    async def bootstrap(self, **kwargs):
+        self.is_built: bool = True
+        self.params: self.Parameters = self.Parameters(**self.parameters)
+
+    async def run(self, request, data: Module.ResultSet, **kwargs):
+        return ProcessedData(data.get(RawData)[::-1])
+
+    async def teardown(self):
+        self.is_built: bool = False
+        return super().teardown()
+
+
+@pytest.mark.parametrize('module_cls', [ModuleAsync, ModuleSync])
+@pytest.mark.asyncio
+class TestTestingModule:
+    async def test_should_process_correctly(self, module_cls):
+        module = module_cls('my-module-a').set_parameters({'param': 'value'})
+        mock = await ModuleTestingWrapper(module).build()
+
+        result = await mock.run(data=RawData('xyz'), request={'query': 'query'})
+        assert result == ProcessedData('zyx')
+
+    async def test_should_not_compile(self, module_cls):
+        module = module_cls('my-module-a').set_parameters({}) # Missing required params
+
+        with pytest.raises(TypeError):
+            await ModuleTestingWrapper(module).build()
+
+    async def test_should_correctyl_bootstrap(self, module_cls):
+        module = module_cls('my-module-a').set_parameters({'param': 'value'})
+        mock = await ModuleTestingWrapper(module).build()
+        assert mock.module.is_built
+    
+    async def test_should_correctly_teardown(self, module_cls):
+        module = module_cls('my-module-a').set_parameters({'param': 'value'})
+        mock = await ModuleTestingWrapper(module).build()
+        await mock.close()
+        assert not mock.module.is_built
+    
+    async def test_should_correctly_pass_shared_parameters(self, module_cls):
+        shared_parameters={'shared_param': 'value'}
+        module = module_cls('my-module-a').set_parameters({'param': 'value'})
+        mock = await ModuleTestingWrapper(module).build(shared_parameters=shared_parameters)
+        assert mock.module.shared_parameters == shared_parameters
+
+    async def test_should_correctly_pass_context(self, module_cls):
+        def get_context():
+            return 'callabel context'
+
+        module = module_cls('my-module-a').set_parameters({'param': 'value'})
+        mock = await ModuleTestingWrapper(module).build(context=get_context)
+        assert mock.module.context() == get_context()
+
+
+class TestTestingModuleOnlyData:
+    @pytest.mark.asyncio
+    async def test_should_process_correctly(self):
+        module = ModuleOnlyData('my-module-a').set_parameters({'param': 'value'})
+        mock = await ModuleTestingWrapper(module).build()
+
+        result = await mock.run(RawData('xyz'))
+        assert result == ProcessedData('zyx')
+
+
+class TestWrapIntoResult:
+    def test_should_pass(self):
+        data: RawData = RawData('xyz')
+        interface = RawData
+        name = 'raw_data'
+        src_class = ModuleSync
+        expose = 'expose'
+        result: Module.Result = wrap_into_result(data, name, src_class, expose)
+
+        assert isinstance(result, Module.Result)
+        assert result.result == data
+        assert result.interface == interface
+        assert result.name == name
+        assert result.src_class == src_class
+        assert result.expose == expose
+
+    def test_should_fail(self):
+        with pytest.raises(TypeError):
+            wrap_into_result()
+
+
+class TestWrapDataIntoResultSet:
+    params_names = 'arg_names, args, kwargs'
+    params_pass = [
+        (['request', 'data'], ({'query': 'example_query'}, RawData('xyz')), {}),
+        (['request', 'data'], ({'query': 'example_query'},), {'data': RawData('xyz')}),
+        (['request', 'data'], (RawData('xyz'),), {'request': {'query': 'example_query'}}),
+        (['request', 'data'], tuple(), {'request': {'query': 'example_query'}, 'data': RawData('xyz')}),
+        (['data'], (RawData('xyz'),), {}),
+        (['data'], tuple(), {'data': RawData('xyz')}),
+        (['data'], (RawData('xyz'),), {'request': {'query': 'example_query'}}),
+        (['data'], tuple(), {'request': {'query': 'example_query'}, 'data': RawData('xyz')}),
+        ([], ({'query': 'example_query'},), {'data': RawData('xyz')}),
+        ([], tuple(), {'request': {'query': 'example_query'}, 'data': RawData('xyz')}),
+        (['request'], ({'query': 'example_query'},), {}),
+        (['request'], tuple(), {'request': {'query': 'example_query'}})
+    ]
+
+    @pytest.mark.parametrize(params_names, params_pass)
+    def test_should_pass(self, arg_names, args, kwargs):
+        target_data = RawData('xyz')
+        wrap = wrap_single_object_into_resultset
+        target_args = tuple([arg if arg != target_data else wrap(target_data) for arg in args])
+        target_kwargs = {key: val if val != target_data else wrap(val) for key, val in kwargs.items()}
+        wrapped_args, wrapped_kwargs = wrap_data_into_resultset(arg_names, *args, **kwargs)
+
+        def equals(obj1, obj2):
+            if isinstance(obj1, Module.ResultSet) and isinstance(obj2, Module.ResultSet):
+                return obj1.collection == obj2.collection
+            else:
+                return obj1 == obj2
+        
+        assert all([equals(w, t) for (w, t) in zip(wrapped_args, target_args)])
+        assert all([equals(wrapped_kwargs[key], target_kwargs[key]) for key in target_kwargs.keys()])

--- a/test/test_testing_utils.py
+++ b/test/test_testing_utils.py
@@ -1,0 +1,25 @@
+import pytest
+from magda.module import Module
+from magda.testing.utils import wrap_into_result
+from test.test_module_testing_wrapper import RawData, ModuleSync
+
+
+class TestWrapIntoResult:
+    def test_should_pass(self):
+        data: RawData = RawData('xyz')
+        interface = RawData
+        name = 'raw_data'
+        src_class = ModuleSync
+        expose = 'expose'
+        result: Module.Result = wrap_into_result(data, name, src_class, expose)
+
+        assert isinstance(result, Module.Result)
+        assert result.result == data
+        assert result.interface == interface
+        assert result.name == name
+        assert result.src_class == src_class
+        assert result.expose == expose
+
+    def test_should_fail(self):
+        with pytest.raises(TypeError):
+            wrap_into_result()

--- a/test/test_testing_utils.py
+++ b/test/test_testing_utils.py
@@ -5,7 +5,7 @@ from test.test_module_testing_wrapper import RawData, ModuleSync
 
 
 class TestWrapIntoResult:
-    def test_should_pass(self):
+    def test_should_wrap_data_into_result(self):
         data: RawData = RawData('xyz')
         interface = RawData
         name = 'raw_data'
@@ -20,6 +20,13 @@ class TestWrapIntoResult:
         assert result.src_class == src_class
         assert result.expose == expose
 
-    def test_should_fail(self):
+    def test_should_fail_for_missing_data(self):
         with pytest.raises(TypeError):
             wrap_into_result()
+
+    def test_should_accept_missing_arguments(self):
+        data: RawData = RawData('xyz')
+        result: Module.Result = wrap_into_result(data)
+
+        assert isinstance(result, Module.Result)
+        assert result.result == data


### PR DESCRIPTION
### Overview
Issue https://github.com/NeuroSYS-pl/magda/issues/12 solved.

The issue's aim is to create a simple wrapper for [magda.module.runtime.ModuleRuntime](https://github.com/NeuroSYS-pl/magda/blob/main/magda/module/runtime.py) called `ModuleTestingWrapper`. Its interface mimics [SequentialPipeline](https://github.com/NeuroSYS-pl/magda/blob/main/magda/pipeline/sequential.py) interface, but the whole class is much simpler, for example, it does not include building [Graph](https://github.com/NeuroSYS-pl/magda/blob/83bdaf3472eba7b9be6f8000b670ab50997d5a66/magda/pipeline/graph.py) which is responsible for running modules in normal magda's pipeline. `ModuleTestingWrapper` enables simple testing of modules due to automation of calling `bootstrap` and `teardown` methods and taking care of wrapping data object into [magda.module.results.ResultSet](https://github.com/NeuroSYS-pl/magda/blob/83bdaf3472eba7b9be6f8000b670ab50997d5a66/magda/module/results.py#L23) object.